### PR TITLE
soong: Set a default for TARGET_ADDITIONAL_GRALLOC_10_USAGE_BITS

### DIFF
--- a/config/BoardConfigSoong.mk
+++ b/config/BoardConfigSoong.mk
@@ -93,6 +93,7 @@ SOONG_CONFIG_nezukoQcomVars_supports_debug_accessory := $(TARGET_QTI_USB_SUPPORT
 
 # Set default values
 BOOTLOADER_MESSAGE_OFFSET ?= 0
+TARGET_ADDITIONAL_GRALLOC_10_USAGE_BITS ?= 0
 TARGET_INIT_VENDOR_LIB ?= vendor_init
 TARGET_SPECIFIC_CAMERA_PARAMETER_LIBRARY ?= libcamera_parameters
 TARGET_SURFACEFLINGER_FOD_LIB ?= surfaceflinger_fod_lib


### PR DESCRIPTION
Devices not setting BOARD_USES_QCOM_HARDWARE to true fail to build
in case a default is not set.

Change-Id: I6643aa08244a5c476a45336485362dd7876fc90c
Signed-off-by: sarthakroy2002 <sarthakroy2002@gmail.com>